### PR TITLE
fix dark theme for signIn and signUp screen

### DIFF
--- a/app/src/main/res/drawable/bg_edt.xml
+++ b/app/src/main/res/drawable/bg_edt.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <solid android:color="#0D174188"/>
+    <solid android:color="@color/textfield_background_color"/>
     <corners android:radius="15dp"/>
 
 </shape>

--- a/app/src/main/res/layout/fragment_sign_in.xml
+++ b/app/src/main/res/layout/fragment_sign_in.xml
@@ -12,7 +12,7 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/white"
+        android:background="@color/home_screen_background"
         tools:context=".Signinactivity">
 
         <RelativeLayout
@@ -29,7 +29,7 @@
                 android:layout_marginBottom="100dp"
                 android:fontFamily="@font/lilitaone_regular"
                 android:text="neXtgen"
-                android:textColor="@color/black"
+                android:textColor="@color/home_screen_text_color"
                 android:textSize="50dp" />
 
             <com.google.android.material.textfield.TextInputEditText
@@ -47,7 +47,7 @@
                 android:maxLines="1"
                 android:paddingStart="20dp"
                 android:paddingEnd="20dp"
-                android:textColor="@color/black"
+                android:textColor="@color/home_screen_text_color"
                 android:textColorHint="#7E7B7B"
                 android:textSize="16sp" />
 
@@ -66,7 +66,7 @@
                 android:maxLines="1"
                 android:paddingStart="20dp"
                 android:paddingEnd="20dp"
-                android:textColor="@color/black"
+                android:textColor="@color/home_screen_text_color"
                 android:textColorHint="#7E7B7B"
                 android:textSize="16sp" />
 
@@ -101,7 +101,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Dont have an account ?"
-                    android:textColor="#1F2F33" />
+                    android:textColor="#7E7B7B" />
 
                 <TextView
                     android:id="@+id/signupherebtn"

--- a/app/src/main/res/layout/fragment_signup.xml
+++ b/app/src/main/res/layout/fragment_signup.xml
@@ -14,7 +14,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".signup.SignupSigninActivity"
-        android:background="@color/white">
+        android:background="@color/home_screen_background">
 
         <RelativeLayout
             android:layout_width="match_parent"
@@ -30,7 +30,7 @@
                 android:layout_marginBottom="100dp"
                 android:fontFamily="@font/lilitaone_regular"
                 android:text="neXtgen"
-                android:textColor="@color/black"
+                android:textColor="@color/home_screen_text_color"
                 android:textSize="50dp" />
 
             <com.google.android.material.textfield.TextInputEditText
@@ -49,7 +49,7 @@
                 android:maxLines="1"
                 android:paddingStart="20dp"
                 android:paddingEnd="20dp"
-                android:textColor="@color/black"
+                android:textColor="@color/home_screen_text_color"
                 android:textColorHint="#7E7B7B"
                 android:textSize="16sp" />
 
@@ -69,7 +69,7 @@
                 android:maxLines="1"
                 android:paddingStart="20dp"
                 android:paddingEnd="20dp"
-                android:textColor="@color/black"
+                android:textColor="@color/home_screen_text_color"
                 android:textColorHint="#7E7B7B"
                 android:textSize="16sp" />
 
@@ -88,7 +88,7 @@
                 android:maxLines="1"
                 android:paddingStart="20dp"
                 android:paddingEnd="20dp"
-                android:textColor="@color/black"
+                android:textColor="@color/home_screen_text_color"
                 android:textColorHint="#7E7B7B"
                 android:textSize="16sp" />
 
@@ -122,7 +122,7 @@
                     android:id="@+id/signupherebt"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:textColor="#1F2F33"
+                    android:textColor="#7E7B7B"
                     android:text="Already have an account ?" />
 
                 <TextView

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -16,4 +16,5 @@
     <color name="home_screen_text_color">#FFFFFF</color>
     <color name="divider_color">#564E4E</color>
     <color name="message_recyclerView_background">#121111</color>
+    <color name="textfield_background_color">#0DFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -16,4 +16,5 @@
     <color name="home_screen_text_color">#141212</color>
     <color name="divider_color">#C3BCBC</color>
     <color name="message_recyclerView_background">#FFFFFF</color>
+    <color name="textfield_background_color">#0D174188</color>
 </resources>


### PR DESCRIPTION
 #64 

[ ✓] My code follows the style guidelines of this project
[ ✓] I have performed a self-review of my code
[✓ ] I have commented on my code, particularly in hard-to-understand areas
[✓ ] My changes generate no new warnings

These are screenshot for the provided issue

![dark Theme SignIn ](https://github.com/user-attachments/assets/7cae46a1-39de-4b64-8c36-03f09e90acfb)
![Dark Theme SignIn with text](https://github.com/user-attachments/assets/c0c7a545-cf1e-49ce-872b-077931e36161)
![dark Theme Signup with text](https://github.com/user-attachments/assets/daa8bdde-1f38-4f07-b81b-18c3f0e76813)
![dark Theme Signup](https://github.com/user-attachments/assets/9545ea97-fcd7-4ae3-8b94-8f0eaae35bc3)
