### PR TITLE
Migrating the Privacy Fragment to constraint layout

### DIFF
--- a/app/src/main/res/layout/activity_privacy.xml
+++ b/app/src/main/res/layout/activity_privacy.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".privacy.PrivacyActivity">
-    <!-- AppBarLayout with Toolbar -->
+
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar"
         android:layout_width="0dp"
@@ -20,7 +20,6 @@
             app:title="Privacy" />
     </com.google.android.material.appbar.AppBarLayout>
 
-    <!-- RecyclerView for Privacy Items below the AppBarLayout -->
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/privacy_recycler_view"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_privacy.xml
+++ b/app/src/main/res/layout/activity_privacy.xml
@@ -5,9 +5,29 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".privacy.PrivacyActivity">
-    <FrameLayout
-        android:id="@+id/frame_layout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        />
+    <!-- AppBarLayout with Toolbar -->
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar"
+        android:layout_width="0dp"
+        android:layout_height="50dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <androidx.appcompat.widget.Toolbar
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:title="Privacy" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <!-- RecyclerView for Privacy Items below the AppBarLayout -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/privacy_recycler_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/appbar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Description
I successfully migrated the UI of the Privacy Screen from Frame Layout to Constraint layout

fixes #81 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

 ## Screenshot of successful build.
![Screenshot 2024-10-11 at 6 53 15 PM](https://github.com/user-attachments/assets/a6fe5f3a-2301-45f2-8736-969135002f0f)


## Screenshots / Screen Recordings
![Screenshot 2024-10-11 at 6 47 20 PM](https://github.com/user-attachments/assets/8509b9ae-5eb4-4490-b7b6-fb7a672fa908)
![Screenshot 2024-10-11 at 6 46 10 PM](https://github.com/user-attachments/assets/4c42dcbd-1642-40d8-8dfc-fba6447e55e3)


## Note: Only ask for review when you complete all above.
