### PR TITLE
Fixed Keyboard Dismissal Issue on Signup/SignIn Screen

### DIFF
--- a/app/src/main/java/com/example/nextgen/signup/SignInFragment.kt
+++ b/app/src/main/java/com/example/nextgen/signup/SignInFragment.kt
@@ -1,9 +1,12 @@
 package com.example.nextgen.signup
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
@@ -53,6 +56,14 @@ class SignInFragment : BaseFragment(), RouteToSignupSigninListener {
       )
     }
 
+    binding.root.setOnTouchListener { v, event ->
+      if (event.action == MotionEvent.ACTION_DOWN) {
+        v.performClick()
+        hideKeyboard()
+      }
+      false
+    }
+
     signInViewModel.loginResult.observe(viewLifecycleOwner) {
       when (it) {
         is com.example.utility.Result.Success<*> -> {
@@ -74,6 +85,14 @@ class SignInFragment : BaseFragment(), RouteToSignupSigninListener {
 
     fun newInstance(): SignInFragment {
       return SignInFragment()
+    }
+  }
+
+  private fun hideKeyboard() {
+    val inputMethodManager = requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    val currentFocusView = requireActivity().currentFocus
+    if (currentFocusView != null) {
+      inputMethodManager.hideSoftInputFromWindow(currentFocusView.windowToken, 0)
     }
   }
 

--- a/app/src/main/java/com/example/nextgen/signup/SignupFragment.kt
+++ b/app/src/main/java/com/example/nextgen/signup/SignupFragment.kt
@@ -1,9 +1,12 @@
 package com.example.nextgen.signup
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
@@ -56,6 +59,14 @@ class SignupFragment : BaseFragment(), RouteToSignupSigninListener {
       it.viewModel = signupViewModel
     }
 
+    binding.root.setOnTouchListener { v, event ->
+      if (event.action == MotionEvent.ACTION_DOWN) {
+        v.performClick()
+        hideKeyboard()
+      }
+      false
+    }
+
     binding.signupbtn.setOnClickListener {
       binding.progressBar.visibility = View.VISIBLE
       signupViewModel.onClickSignUp(
@@ -86,6 +97,14 @@ class SignupFragment : BaseFragment(), RouteToSignupSigninListener {
 
     fun newInstance(): SignupFragment {
       return SignupFragment()
+    }
+  }
+
+  private fun hideKeyboard() {
+    val inputMethodManager = requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    val currentFocusView = requireActivity().currentFocus
+    if (currentFocusView != null) {
+      inputMethodManager.hideSoftInputFromWindow(currentFocusView.windowToken, 0)
     }
   }
 


### PR DESCRIPTION
## Description
This PR fixes issue #107, where the keyboard on the signup and signIn screen could only be dismissed by pressing the back button. Now, the keyboard will close when the user taps anywhere on the screen outside of the input fields, improving the user experience.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Screenshot of Successful Build:

![image](https://github.com/user-attachments/assets/e50f0714-0925-4162-9148-406627e126b0)

Screenshots / Screen Recordings

https://github.com/user-attachments/assets/17ef2b9d-da8b-4f9b-a631-c23279fee091

