### PR TITLE
missing whitespace error resolved in the receiver_message_layout.xml (#142)

### DIFF
--- a/app/src/main/res/layout/receiver_message_layout.xml
+++ b/app/src/main/res/layout/receiver_message_layout.xml
@@ -1,11 +1,13 @@
-<?xml version="1.0"encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"><data>
-    <variable
-        name="viewModel"
-        type="com.example.nextgen.message.MessageViewModel" />
-</data>
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="viewModel"
+            type="com.example.nextgen.message.MessageViewModel" />
+    </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -53,5 +55,3 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>
-
-


### PR DESCRIPTION
This pull request addresses issue #142 by correcting the XML declaration error in the `receiver_message_layout.xml` file. The error was caused by a missing whitespace before the `encoding` attribute in the XML declaration, leading to a formatting issue.

#### Changes Made:
- Updated the XML declaration from `<?xml version="1.0"encoding="utf-8"?>` to `<?xml version="1.0" encoding="utf-8"?>`.
- This change resolves the XML parsing error, ensuring correct formatting and compliance with XML standards.

#### Issue Reference:
Fixes #142

#### Additional Notes:
This fix has been tested and verified to eliminate the error. Please review and merge if everything looks good.

--- 